### PR TITLE
containers: Skip building git-server

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -18,7 +18,7 @@ build() {
 #     Directory      Dockerfile        Image Tag Name
 build fedora-updated Dockerfile        fedora-updated
 build sshd           Dockerfile        sshd
-build git-server     Dockerfile        git-server
+# build git-server     Dockerfile        git-server
 build devshell       Dockerfile        devshell
 build ..             Dockerfile-fedora ghcr.io/vorburger/dotfiles-fedora
 ## build gcloud         Dockerfile        gcloud


### PR DESCRIPTION
Because its test fails on GitHub ubuntu-latest instead of self-hosted Runner (see #8),

and its not used anyways; note that devshell is FROM sshd, not git-server.